### PR TITLE
jira: disable service account watching jira issue when creating

### DIFF
--- a/cmd/issue/create-issue.go
+++ b/cmd/issue/create-issue.go
@@ -42,6 +42,10 @@ func createIssue(options *issueCommandOptions) (*jira.Issue, error) {
 			Description: options.description,
 			Project:     *project,
 			Type:        *issueType,
+			Watches: &jira.Watches{
+				IsWatching: false,
+				Watchers:   []*jira.Watcher{},
+			},
 			Security: map[string]interface{}{
 				"id":   "11696",
 				"self": "https://issues.redhat.com/rest/api/2/securitylevel/11696",


### PR DESCRIPTION
Disable bot to self-assign as watcher when creating a Jira issue